### PR TITLE
Experiment/WithCodepen in Pocket

### DIFF
--- a/src/_includes/components/WithCodepen.js
+++ b/src/_includes/components/WithCodepen.js
@@ -15,25 +15,23 @@ module.exports = function(content, props = {}) {
   const htmlContent = html`${content}`;
 
   return html`
-    <div class="md-replaced vs2">
-      <div
-        class="${lazy ? embedIdentifier : 'codepen'}"
-        data-prefill
-        data-height="${height}"
-        data-default-tab="${defaultTab}"
-      >
-        ${htmlContent}
-      </div>
-      ${lazy
-        ? html`
-            <button
-              data-for="${embedIdentifier}"
-              class="makeCpInteractive button-reset ph3 pv2 fw6 fg-secondary bg-primary enhanced-outline-shadow hover-bg-accent transition-bg br2"
-            >
-              Make demo interactive
-            </button>
-          `
-        : ''}
+    <div
+      class="${lazy ? embedIdentifier : 'codepen'}"
+      data-prefill
+      data-height="${height}"
+      data-default-tab="${defaultTab}"
+    >
+      ${htmlContent}
     </div>
+    ${lazy
+      ? html`
+          <button
+            data-for="${embedIdentifier}"
+            class="makeCpInteractive button-reset ph3 pv2 fw6 fg-secondary bg-primary enhanced-outline-shadow hover-bg-accent transition-bg br2"
+          >
+            Make demo interactive
+          </button>
+        `
+      : ''}
   `;
 };

--- a/src/css/components/article.css
+++ b/src/css/components/article.css
@@ -42,12 +42,30 @@
   margin-top: 1.5em;
 }
 
-/* Separate replaced content */
+/* Separate replaced img content */
 .article * + img,
-.article * + iframe,
-.article * + .md-img,
-.article * + .md-replaced {
+.article * + .md-img {
   margin-top: 1.5em;
+}
+
+/* NOTE:
+ * iframes and .md-replaced can be nested, so set
+ * margin-top always. False positives are unlikely!
+*/
+.article .md-replaced,
+.article iframe {
+  margin-top: 1.5em;
+}
+
+/* For pre, we want to keep subsequent ones close,
+ * and separate everything else.
+*/
+.article pre {
+  margin-top: 1.5em;
+}
+
+.article pre + pre {
+  margin-top: 0.5em;
 }
 
 /* SEPARATORS */

--- a/src/posts/resilient-code-examples.md
+++ b/src/posts/resilient-code-examples.md
@@ -147,26 +147,24 @@ module.exports = function(content, props = {}) {
   const htmlContent = html`${content}`;
 
   return html`
-    <div class="md-replaced vs2">
-      <div
-        class="${lazy ? embedIdentifier : 'codepen'}"
-        data-prefill
-        data-height="${height}"
-        data-default-tab="${defaultTab}"
-      >
-        ${htmlContent}
-      </div>
-      ${lazy
-        ? html`
-            <button
-              data-for="${embedIdentifier}"
-              class="makeCpInteractive"
-            >
-              Make demo interactive
-            </button>
-          `
-        : ''}
+    <div
+      class="${lazy ? embedIdentifier : 'codepen'}"
+      data-prefill
+      data-height="${height}"
+      data-default-tab="${defaultTab}"
+    >
+      ${htmlContent}
     </div>
+    ${lazy
+      ? html`
+          <button
+            data-for="${embedIdentifier}"
+            class="makeCpInteractive"
+          >
+            Make demo interactive
+          </button>
+        `
+      : ''}
   `;
 };
 {% endhighlight %}


### PR DESCRIPTION
For some reason, `WithCodepen` works well in Reader mode and printing, but Pocket seems to remove the block altogether. Pocket works with (and even styles a bit) `pre` tags, even on this blog, when they don't have the WithCodepen setup. I am not sure why it happens.

This PR is here to get things online, so that I can test on Pocket. I wish there was an easier way.

## List of things attempted
- [x] Remove the extra wrapper `div`, that pairs the `pre` tags and the `button`

## Summary
First guess was correct! Seems Pocket is happy with one nested `div` but not two :/ Patched for now, but I want to find a good reason for that :)

Update: The plot thickens
Pocket seems happy with the preview in "Resilient Code Examples", but not in "Linking to Headings".  ... how?

Should try html minification as an attempt to normalise, perhaps.